### PR TITLE
Max service execution time

### DIFF
--- a/src/Commands/Serve.php
+++ b/src/Commands/Serve.php
@@ -13,7 +13,7 @@ use Stackflows\Stackflows;
 
 class Serve extends Command
 {
-    public $signature = 'stackflows:serve {chunk=10 : Single chunk size} {topic? : Serve a specific topic} {--once : Run only once}';
+    public $signature = 'stackflows:serve {chunk=10 : Single chunk size} {topic? : Serve a specific topic} {--once : Run only once} {--max-time=0 : The maximum number of seconds the service should run}';
 
     public $description = 'This command will start executing business processes service tasks endlessly';
 
@@ -26,6 +26,7 @@ class Serve extends Command
     {
         $chunk = $this->input->getArgument('chunk');
         $topic = $this->input->getArgument('topic');
+        $startTime = Carbon::now()->timestamp;
 
         /** @var ServiceTaskExecutorInterface[] $executors */
         $executors = app()->tagged('stackflows:executor');
@@ -153,6 +154,15 @@ class Serve extends Command
             }
 
             if ($this->option('once')) {
+                break;
+            }
+            if ((int)$this->option('max-time') !== 0 && $this->option('max-time') <= (Carbon::now()->timestamp - $startTime)) {
+                $this->output->writeln(
+                    sprintf(
+                        'Service is restarting after %s seconds.',
+                        (Carbon::now()->timestamp - $startTime)
+                    )
+                );
                 break;
             }
 

--- a/src/Commands/Sync/SyncTasks.php
+++ b/src/Commands/Sync/SyncTasks.php
@@ -185,7 +185,6 @@ class SyncTasks extends Command
                 break;
             }
 
-
             sleep(1);
         }
     }

--- a/src/Commands/Sync/SyncTasks.php
+++ b/src/Commands/Sync/SyncTasks.php
@@ -19,7 +19,7 @@ class SyncTasks extends Command
      *
      * @var string
      */
-    protected $signature = 'stackflows:sync:tasks';
+    protected $signature = 'stackflows:sync:tasks {--max-time=0 : The maximum number of seconds the service should run}';
 
     /**
      * The console command description.
@@ -46,6 +46,7 @@ class SyncTasks extends Command
     public function handle(Stackflows $stackflows)
     {
         $nextAfter = Carbon::now()->subDays(7);
+        $startTime = Carbon::now()->timestamp;
 
         $size = 100;
 
@@ -173,6 +174,17 @@ class SyncTasks extends Command
                     );
                 }
             }
+
+            if ((int)$this->option('max-time') !== 0 && $this->option('max-time') <= (Carbon::now()->timestamp - $startTime)) {
+                $this->output->writeln(
+                    sprintf(
+                        'Service is restarting after %s seconds.',
+                        (Carbon::now()->timestamp - $startTime)
+                    )
+                );
+                break;
+            }
+
 
             sleep(1);
         }


### PR DESCRIPTION
Introduced max service execution time on service command stackflows:sync:tasks and stackflows:serve as optional parameter `--max-time`.